### PR TITLE
Bumping version of ace-builds to 1.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.4.tgz",
-      "integrity": "sha512-EQArUYup9c3lBv8meKBjisff/qhhQmU/6LnLhVDfxe+Bnjr0Lz7qhL4Mp8HpwNQzmCqLunjdPFuBtCELVVG6zw=="
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.8.tgz",
+      "integrity": "sha512-8ZVAxwyCGAxQX8mOp9imSXH0hoSPkGfy8igJy+WO/7axL30saRhKgg1XPACSmxxPA7nfHVwM+ShWXT+vKsNuFg=="
     },
     "acorn": {
       "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "ace-builds"
   ],
   "dependencies": {
-    "ace-builds": "^1.4.4",
+    "ace-builds": "^1.4.8",
     "diff-match-patch": "^1.0.4",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0"


### PR DESCRIPTION
# What's in this PR?

## List the changes you made and your reasons for them.

- Updating the `ace-builds` version to the most recent one: `1.4.8`

## References

### Fixes #

### Progress on: #